### PR TITLE
Refactor: Remove type hints from release 4.1.3 so this is compatible with php 7.3

### DIFF
--- a/.github/workflows/codequality.yml
+++ b/.github/workflows/codequality.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup PHP Action
       uses: shivammathur/setup-php@2.3.1
       with:
-        php-version: '7.4'
+        php-version: '7.3'
         tools: php-cs-fixer:2.16.4
 
     - name: Code Reformatting...
@@ -28,7 +28,4 @@ jobs:
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
         branch: ${{ github.head_ref }}
-        commit_author: lanlin <lanlin1987@github.com>
         commit_message: code reformat workflow
-        commit_user_name: lanlin
-        commit_user_email: lanlin1987@gmail.com

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup PHP Action
       uses: shivammathur/setup-php@2.3.1
       with:
-        php-version: '7.4'
+        php-version: '7.3'
         coverage: pcov
 
     - name: Validate composer.json and composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,20 +1,24 @@
 {
     "name": "lanlin/nylas-php",
-    "description": "Nylas PHP SDK (api version 2.0)",
+    "description": "Nylas PHP SDK (api version 2.1)",
     "license": "MIT",
     "authors" : [
         {
           "name": "lanlin",
           "email": "lanlin1987@gmail.com"
+        },
+        {
+          "name": "jgriffin",
+          "email": "jgriffin.cmh@gmail.com"
         }
     ],
-    "require": {
+  "require": {
         "php": ">=7.3",
         "guzzlehttp/guzzle": ">=6.5",
         "respect/validation": "^2.0",
         "zbateson/mail-mime-parser": "^1.2",
-      "ext-json": "*",
-      "ext-fileinfo": "*"
+        "ext-json": "*",
+        "ext-fileinfo": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.2"

--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,12 @@
         }
     ],
     "require": {
-        "php": ">=7.4",
+        "php": ">=7.3",
         "guzzlehttp/guzzle": ">=6.5",
         "respect/validation": "^2.0",
-        "zbateson/mail-mime-parser": "^1.2"
+        "zbateson/mail-mime-parser": "^1.2",
+      "ext-json": "*",
+      "ext-fileinfo": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.2"

--- a/src/Accounts/Account.php
+++ b/src/Accounts/Account.php
@@ -21,7 +21,7 @@ class Account
     /**
      * @var \Nylas\Utilities\Options
      */
-    private Options $options;
+    private $options;
 
     // ------------------------------------------------------------------------------
 

--- a/src/Accounts/Manage.php
+++ b/src/Accounts/Manage.php
@@ -22,7 +22,7 @@ class Manage
     /**
      * @var \Nylas\Utilities\Options
      */
-    private Options $options;
+    private $options;
 
     // ------------------------------------------------------------------------------
 

--- a/src/Authentication/Hosted.php
+++ b/src/Authentication/Hosted.php
@@ -21,7 +21,7 @@ class Hosted
     /**
      * @var \Nylas\Utilities\Options
      */
-    private Options $options;
+    private $options;
 
     // ------------------------------------------------------------------------------
 

--- a/src/Authentication/Native.php
+++ b/src/Authentication/Native.php
@@ -21,7 +21,7 @@ class Native
     /**
      * @var array
      */
-    private array $providers =
+    private $providers =
     [
         'gmail', 'yahoo', 'exchange', 'outlook', 'imap', 'icloud', 'hotmail', 'aol',
     ];
@@ -31,7 +31,7 @@ class Native
     /**
      * @var \Nylas\Utilities\Options
      */
-    private Options $options;
+    private $options;
 
     // ------------------------------------------------------------------------------
 
@@ -124,13 +124,9 @@ class Native
             case 'yahoo':
             case 'icloud':
             case 'hotmail': return $this->knownProviderRule();
-
-            case 'imap':     return $this->imapProviderRule();
-
             case 'gmail':    return $this->gmailProviderRule();
-
             case 'exchange': return $this->exchangeProviderRule();
-
+            case 'imap':
             default: return $this->imapProviderRule();
         }
     }

--- a/src/Authentication/Native.php
+++ b/src/Authentication/Native.php
@@ -124,9 +124,13 @@ class Native
             case 'yahoo':
             case 'icloud':
             case 'hotmail': return $this->knownProviderRule();
+
+            case 'imap':     return $this->imapProviderRule();
+
             case 'gmail':    return $this->gmailProviderRule();
+
             case 'exchange': return $this->exchangeProviderRule();
-            case 'imap':
+
             default: return $this->imapProviderRule();
         }
     }

--- a/src/Calendars/Calendar.php
+++ b/src/Calendars/Calendar.php
@@ -22,7 +22,7 @@ class Calendar
     /**
      * @var \Nylas\Utilities\Options
      */
-    private Options $options;
+    private $options;
 
     // ------------------------------------------------------------------------------
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -34,7 +34,7 @@ class Client
     /**
      * @var Options
      */
-    private Options $options;
+    private $options;
 
     // ------------------------------------------------------------------------------
 

--- a/src/Contacts/Contact.php
+++ b/src/Contacts/Contact.php
@@ -25,7 +25,7 @@ class Contact
     /**
      * @var \Nylas\Utilities\Options
      */
-    private Options $options;
+    private $options;
 
     // ------------------------------------------------------------------------------
 

--- a/src/Deltas/Delta.php
+++ b/src/Deltas/Delta.php
@@ -21,7 +21,7 @@ class Delta
     /**
      * @var \Nylas\Utilities\Options
      */
-    private Options $options;
+    private $options;
 
     // ------------------------------------------------------------------------------
 

--- a/src/Drafts/Draft.php
+++ b/src/Drafts/Draft.php
@@ -24,7 +24,7 @@ class Draft
     /**
      * @var \Nylas\Utilities\Options
      */
-    private Options $options;
+    private $options;
 
     // ------------------------------------------------------------------------------
 

--- a/src/Drafts/Sending.php
+++ b/src/Drafts/Sending.php
@@ -22,7 +22,7 @@ class Sending
     /**
      * @var \Nylas\Utilities\Options
      */
-    private Options $options;
+    private $options;
 
     // ------------------------------------------------------------------------------
 
@@ -79,7 +79,7 @@ class Sending
     // ------------------------------------------------------------------------------
 
     /**
-     * get rules for draf
+     * get rules for draft
      *
      * @return \Nylas\Utilities\Validator
      */

--- a/src/Drafts/Sending.php
+++ b/src/Drafts/Sending.php
@@ -79,7 +79,7 @@ class Sending
     // ------------------------------------------------------------------------------
 
     /**
-     * get rules for draft
+     * get rules for draf
      *
      * @return \Nylas\Utilities\Validator
      */

--- a/src/Events/Event.php
+++ b/src/Events/Event.php
@@ -24,7 +24,7 @@ class Event
     /**
      * @var \Nylas\Utilities\Options
      */
-    private Options $options;
+    private $options;
 
     // ------------------------------------------------------------------------------
 

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -23,7 +23,7 @@ class File
     /**
      * @var \Nylas\Utilities\Options
      */
-    private Options $options;
+    private $options;
 
     // ------------------------------------------------------------------------------
 

--- a/src/Folders/Folder.php
+++ b/src/Folders/Folder.php
@@ -22,7 +22,7 @@ class Folder
     /**
      * @var \Nylas\Utilities\Options
      */
-    private Options $options;
+    private $options;
 
     // ------------------------------------------------------------------------------
 

--- a/src/Labels/Label.php
+++ b/src/Labels/Label.php
@@ -22,7 +22,7 @@ class Label
     /**
      * @var \Nylas\Utilities\Options
      */
-    private Options $options;
+    private $options;
 
     // ------------------------------------------------------------------------------
 

--- a/src/Messages/Message.php
+++ b/src/Messages/Message.php
@@ -25,7 +25,7 @@ class Message
     /**
      * @var \Nylas\Utilities\Options
      */
-    private Options $options;
+    private $options;
 
     // ------------------------------------------------------------------------------
 

--- a/src/Messages/Search.php
+++ b/src/Messages/Search.php
@@ -21,7 +21,7 @@ class Search
     /**
      * @var \Nylas\Utilities\Options
      */
-    private Options $options;
+    private $options;
 
     // ------------------------------------------------------------------------------
 

--- a/src/Messages/Sending.php
+++ b/src/Messages/Sending.php
@@ -23,7 +23,7 @@ class Sending
     /**
      * @var \Nylas\Utilities\Options
      */
-    private Options $options;
+    private $options;
 
     // ------------------------------------------------------------------------------
 

--- a/src/Messages/Smart.php
+++ b/src/Messages/Smart.php
@@ -24,7 +24,7 @@ class Smart
     /**
      * @var \Nylas\Utilities\Options
      */
-    private Options $options;
+    private $options;
 
     // ------------------------------------------------------------------------------
 

--- a/src/Request/AbsBase.php
+++ b/src/Request/AbsBase.php
@@ -188,7 +188,7 @@ trait AbsBase
     // ------------------------------------------------------------------------------
 
     /**
-     * concat response data when invalid json data responded
+     * concat response data when invalid json data responsed
      *
      * @param array  $type
      * @param string $code
@@ -220,7 +220,7 @@ trait AbsBase
         $temp =
         [
             'debug'       => $this->debug,
-            'on_headers'  => $this->onHeadersFunctions(),
+            'on_headers'  => $this->onHeadersFuncions(),
             'http_errors' => $httpErrors
         ];
 
@@ -239,7 +239,7 @@ trait AbsBase
     /**
      * check http status code before response body
      */
-    private function onHeadersFunctions() : callable
+    private function onHeadersFuncions() : callable
     {
         $request = $this;
         $excpArr = Errors::StatusExceptions;

--- a/src/Request/AbsBase.php
+++ b/src/Request/AbsBase.php
@@ -30,17 +30,17 @@ trait AbsBase
     /**
      * @var \GuzzleHttp\Client
      */
-    private Client $guzzle;
+    private $guzzle;
 
     // ------------------------------------------------------------------------------
 
-    private array $formFiles     = [];
-    private array $pathParams    = [];
-    private array $jsonParams    = [];
-    private array $queryParams   = [];
-    private array $headerParams  = [];
-    private array $bodyContents  = [];
-    private array $onHeadersFunc = [];
+    private $formFiles     = [];
+    private $pathParams    = [];
+    private $jsonParams    = [];
+    private $queryParams   = [];
+    private $headerParams  = [];
+    private $bodyContents  = [];
+    private $onHeadersFunc = [];
 
     // ------------------------------------------------------------------------------
 
@@ -188,7 +188,7 @@ trait AbsBase
     // ------------------------------------------------------------------------------
 
     /**
-     * concat response data when invalid json data responsed
+     * concat response data when invalid json data responded
      *
      * @param array  $type
      * @param string $code
@@ -220,7 +220,7 @@ trait AbsBase
         $temp =
         [
             'debug'       => $this->debug,
-            'on_headers'  => $this->onHeadersFuncions(),
+            'on_headers'  => $this->onHeadersFunctions(),
             'http_errors' => $httpErrors
         ];
 
@@ -239,7 +239,7 @@ trait AbsBase
     /**
      * check http status code before response body
      */
-    private function onHeadersFuncions() : callable
+    private function onHeadersFunctions() : callable
     {
         $request = $this;
         $excpArr = Errors::StatusExceptions;

--- a/src/Threads/Search.php
+++ b/src/Threads/Search.php
@@ -21,7 +21,7 @@ class Search
     /**
      * @var \Nylas\Utilities\Options
      */
-    private Options $options;
+    private $options;
 
     // ------------------------------------------------------------------------------
 

--- a/src/Threads/Smart.php
+++ b/src/Threads/Smart.php
@@ -24,7 +24,7 @@ class Smart
     /**
      * @var \Nylas\Utilities\Options
      */
-    private Options $options;
+    private $options;
 
     // ------------------------------------------------------------------------------
 

--- a/src/Threads/Thread.php
+++ b/src/Threads/Thread.php
@@ -22,7 +22,7 @@ class Thread
     /**
      * @var \Nylas\Utilities\Options
      */
-    private Options $options;
+    private $options;
 
     // ------------------------------------------------------------------------------
 

--- a/src/Utilities/Abs.php
+++ b/src/Utilities/Abs.php
@@ -19,7 +19,7 @@ trait Abs
     /**
      * @var Options
      */
-    private Options $options;
+    private $options;
 
     // ------------------------------------------------------------------------------
 

--- a/src/Utilities/Options.php
+++ b/src/Utilities/Options.php
@@ -27,32 +27,32 @@ class Options
     /**
      * @var bool
      */
-    private bool $debug = false;
+    private $debug = false;
 
     /**
      * @var string
      */
-    private string $clientId;
+    private $clientId;
 
     /**
      * @var string
      */
-    private string $clientSecret;
+    private $clientSecret;
 
     /**
      * @var string
      */
-    private string $accessToken;
+    private $accessToken;
 
     /**
      * @var string
      */
-    private string $accountId;
+    private $accountId;
 
     /**
      * @var array
      */
-    private array $accountInfo;
+    private $accountInfo;
 
     // ------------------------------------------------------------------------------
 

--- a/src/Webhooks/Webhook.php
+++ b/src/Webhooks/Webhook.php
@@ -22,7 +22,7 @@ class Webhook
     /**
      * @var \Nylas\Utilities\Options
      */
-    private Options $options;
+    private $options;
 
     // ------------------------------------------------------------------------------
 

--- a/tests/AbsCase.php
+++ b/tests/AbsCase.php
@@ -22,7 +22,7 @@ class AbsCase extends TestCase
     /**
      * @var Client
      */
-    protected Client $client;
+    protected $client;
 
     // ------------------------------------------------------------------------------
 


### PR DESCRIPTION
Because I can not update my application to php7.4 just yet, I am proposing this as release version 3.6.0.
