### PR TITLE
Fix: Webhook API::List constants casing.

### DIFF
--- a/src/Utilities/API.php
+++ b/src/Utilities/API.php
@@ -92,7 +92,7 @@ class API
         'searchMessages' => '/messages/search',
 
         // Webhooks
-        'Webhooks'   => '/a/%s/webhooks',
+        'webhooks'   => '/a/%s/webhooks',
         'oneWebhook' => '/a/%s/webhooks/%s',
 
         // Deltas

--- a/tests/WebhookTest.php
+++ b/tests/WebhookTest.php
@@ -46,7 +46,7 @@ class WebhookTest extends AbsCase
 
     // ------------------------------------------------------------------------------
 
-    public function testUpdateWebhook($id): void
+    public function testUpdateWebhook($id = ''): void
     {
         $id = $id ?: \uniqid();
 
@@ -57,7 +57,7 @@ class WebhookTest extends AbsCase
 
     // ------------------------------------------------------------------------------
 
-    public function testGetWebhook($id): void
+    public function testGetWebhook($id = ''): void
     {
         $id = $id ?: \uniqid();
 
@@ -68,7 +68,7 @@ class WebhookTest extends AbsCase
 
     // ------------------------------------------------------------------------------
 
-    public function testDeleteWebhook($id): void
+    public function testDeleteWebhook($id = ''): void
     {
         try
         {


### PR DESCRIPTION
Correction to API::List constant identifier of webhooks.