### PR TITLE
fix: bool get query parameters need to be strings

### DIFF
--- a/src/Events/Event.php
+++ b/src/Events/Event.php
@@ -58,6 +58,23 @@ class Event
 
         $header = ['Authorization' => $accessToken];
 
+        //boolean parameters passed as get query have to be string true/false
+        if (array_key_exists('show_cancelled', $params)) {
+            if ($params['show_cancelled']) {
+                $params['show_cancelled'] = 'true';
+            }  else {
+                $params['show_cancelled'] = 'false';
+            }
+        }
+
+        if (array_key_exists('expand_recurring', $params)) {
+            if ($params['expand_recurring']) {
+                $params['expand_recurring'] = 'true';
+            }  else {
+                $params['expand_recurring'] = 'false';
+            }
+        }
+
         return $this->options
             ->getSync()
             ->setQuery($params)


### PR DESCRIPTION
Nylas returns an invalid_request_error with the message:  Value must be "true" or "false" (not "1") for expand_recurring

This is a solution to get it to work for me right now.  However, it's not generic and doesn't apply to every situation.  I am still looking on how to improve that,  there are potential occurrences of this same issue in Thread, Contact, Message.  

This could be a better solution, but it doesn't match the spec:

```diff --git a/src/Events/Event.php b/src/Events/Event.php
index 8ff8c5b..078a9de 100644
--- a/src/Events/Event.php
+++ b/src/Events/Event.php
@@ -284,8 +284,8 @@ class Event
             V::keyOptional('title', V::stringType()->notEmpty()),
             V::keyOptional('location', V::stringType()->notEmpty()),
             V::keyOptional('description', V::stringType()->notEmpty()),
-            V::keyOptional('show_cancelled', V::boolType()),
-            V::keyOptional('expand_recurring', V::boolType()),
+            V::keyOptional('show_cancelled', V::in(['true', 'false'])),
+            V::keyOptional('expand_recurring', V::in(['true', 'false'])),

             V::keyOptional('ends_after', V::timestampType()),
             V::keyOptional('ends_before', V::timestampType()),


Let me know what you think.