### PR TITLE
fix: fixed GitHub action failing

### DIFF
--- a/.github/workflows/codequality.yml
+++ b/.github/workflows/codequality.yml
@@ -16,7 +16,7 @@ jobs:
         token: ${{ secrets.ACTION_TOKEN }}
 
     - name: Setup PHP Action
-      uses: shivammathur/setup-php@2.3.1
+      uses: shivammathur/setup-php@2.12.0
       with:
         php-version: '7.4'
         tools: php-cs-fixer:2.16.4

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v2
       
     - name: Setup PHP Action
-      uses: shivammathur/setup-php@2.3.1
+      uses: shivammathur/setup-php@2.12.0
       with:
         php-version: '7.4'
         coverage: pcov


### PR DESCRIPTION
Setup PHP action was failing because of GitHub changes to workflows fixing CVE. Was fixed in [2.6.0](https://github.com/shivammathur/setup-php/releases/tag/2.6.0), but updating to newest version (IMO) makes more sense.