### PR TITLE
PHP 8.1 deprecation passing null to http_build_query()

### DIFF
--- a/src/Authentication/Hosted.php
+++ b/src/Authentication/Hosted.php
@@ -59,7 +59,7 @@ class Hosted
             V::keyOptional('login_hint', V::email())
         ), $params);
 
-        $query  = \http_build_query($params, null, '&', PHP_QUERY_RFC3986);
+        $query  = \http_build_query($params, '', '&', PHP_QUERY_RFC3986);
         $apiUrl = \trim($this->options->getServer(), '/').API::LIST['oAuthAuthorize'];
 
         return \trim($apiUrl, '/').'?'.$query;


### PR DESCRIPTION
PHP 8.1 throws a deprecation notice if you try to pass null as the second argument to http_build_query() instead of a string