### PR TITLE
fix: webhook trigger typo

### DIFF
--- a/src/Utilities/API.php
+++ b/src/Utilities/API.php
@@ -116,7 +116,7 @@ class API
         'event.created',
         'event.updated',
         'event.deleted',
-        'job.succesful',
+        'job.successful',
         'job.failed',
     ];
 


### PR DESCRIPTION
I'm calling the `createAWebhook` method as:
```
$nylas->Webhooks->Webhook->createAWebhook([
            'callback_url' => $this->siteNylasWebhooksUrl(),
            'state' => 'active',
            'triggers' => [
                'account.connected',
                'account.running',
                'account.stopped',
                'account.invalid',
                'account.sync_error',
                'calendar.created',
                'calendar.updated',
                'calendar.deleted',
                'job.successful',
                'job.failed',
            ],
        ]);
```

And getting the following validation error:
```
All of the required rules must pass for `{ "callback_url": "https://ccabcd1234.coaching.com/api/json/v1/nylas-webhook", "state": "active", "triggers": { "account.connected", "account.running", "account.stopped", "account.invalid", "account.sync_error", ... } }`
```

I noticed this is because the `API::TRIGGERS` has a typo for the `job.successful` trigger