### PR TITLE
Add support for more Availability options

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
   <img width="635" height="217" src="media/nylas-php.png" />
 </div>
 
+# Fork from the excellent Lanlin/nylas-php
+
+Since Nylas has decided not to update their own PHP SDK it is up to us users to keep it improved and the [Lanlin/nylas-php-fork](https://github.com/lanlin/nylas-php) has been a really good alternative offering up to date API-support. There are a few options missing for some of the end-points and this fork was created to add those for our integration work. The plan of course is to send any changes back as PR's to lanlin/nylas-php. 
+
+Latest updates:
+
+**2023-09-04:** Added support for buffer, round_robin and calendars-options when checking for Availability (singe/multiple). 
+
+Below is the main documentation for lanlin/nylas-php
+
+
 # Nylas PHP SDK (latest 5.3.0, see [change-log](https://github.com/lanlin/nylas-php/releases))
 
 [![Build](https://github.com/lanlin/nylas-php/workflows/Testing/badge.svg?branch=master)](https://github.com/lanlin/nylas-php/actions)

--- a/README.md
+++ b/README.md
@@ -2,17 +2,6 @@
   <img width="635" height="217" src="media/nylas-php.png" />
 </div>
 
-# Fork from the excellent Lanlin/nylas-php
-
-Since Nylas has decided not to update their own PHP SDK it is up to us users to keep it improved and the [Lanlin/nylas-php-fork](https://github.com/lanlin/nylas-php) has been a really good alternative offering up to date API-support. There are a few options missing for some of the end-points and this fork was created to add those for our integration work. The plan of course is to send any changes back as PR's to lanlin/nylas-php. 
-
-Latest updates:
-
-**2023-09-04:** Added support for buffer, round_robin and calendars-options when checking for Availability (singe/multiple). 
-
-Below is the main documentation for lanlin/nylas-php
-
-
 # Nylas PHP SDK (latest 5.3.0, see [change-log](https://github.com/lanlin/nylas-php/releases))
 
 [![Build](https://github.com/lanlin/nylas-php/workflows/Testing/badge.svg?branch=master)](https://github.com/lanlin/nylas-php/actions)

--- a/src/Calendars/Availability.php
+++ b/src/Calendars/Availability.php
@@ -125,6 +125,11 @@ class Availability
             V::key('object_type', V::equals('open_hours')),
         );
 
+        $calendars = V::keySet(
+            V::key('account_id', V::stringType()),
+            V::key('calendar_ids', V::simpleArray()),
+        );
+
         return V::keySet(
             V::key('emails', $emailsRules),
             V::key('end_time', V::timestampType()),
@@ -132,7 +137,10 @@ class Availability
             V::key('free_busy', V::simpleArray($freeBusy)),
             V::key('interval_minutes', V::intType()),
             V::key('duration_minutes', V::intType()),
+            V::keyOptional('round_robin', V::stringType()),
+            V::keyOptional('buffer', V::intType()),
             V::keyOptional('open_hours', V::simpleArray($openHours)),
+            V::keyOptional('calendars', V::simpleArray($calendars)),
         );
     }
 

--- a/src/Calendars/Availability.php
+++ b/src/Calendars/Availability.php
@@ -127,7 +127,7 @@ class Availability
 
         $calendars = V::keySet(
             V::key('account_id', V::stringType()),
-            V::key('calendar_ids', V::simpleArray()),
+            V::key('calendar_ids', V::simpleArray(V::stringType())),
         );
 
         return V::keySet(

--- a/src/Events/Validation.php
+++ b/src/Events/Validation.php
@@ -249,7 +249,7 @@ class Validation
     {
         $autocreate = V::keySet(
             V::key('provider', V::in(['Google Meet', 'Zoom Meeting', 'Microsoft Teams'])),
-            V::key('autocreate', V::arrayType()),
+            V::key('autocreate', V::objectType()),
         );
 
         $webEx = V::keySet(


### PR DESCRIPTION
Add support for the following options that can be added when using availabilityForSingleMeetings or availabilityForMultipleMeetings:

- buffer (int)
- round_robin (max-fairness or max-availability)
- calendars (array with accountId and calendarId's)