### PR TITLE
Fixed Management->Account->returnTokenInformation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "lanlin/nylas-php",
+    "name": "eriksaulnier/nylas-php",
     "description": "Nylas PHP SDK (api version 2.7)",
     "license": "MIT",
     "authors" : [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "eriksaulnier/nylas-php",
+    "name": "lanlin/nylas-php",
     "description": "Nylas PHP SDK (api version 2.7)",
     "license": "MIT",
     "authors" : [

--- a/src/Management/Account.php
+++ b/src/Management/Account.php
@@ -239,7 +239,7 @@ class Account
             ->getSync()
             ->setPath($this->options->getClientId(), $accountId)
             ->setHeaderParams($this->options->getAuthorizationHeader(false))
-            ->get(API::LIST['tokenInfo']);
+            ->post(API::LIST['tokenInfo']);
     }
 
     // ------------------------------------------------------------------------------

--- a/src/Management/Account.php
+++ b/src/Management/Account.php
@@ -229,15 +229,18 @@ class Account
      * @see https://developer.nylas.com/docs/api/v2/#post-/a/client_id/accounts/id/token-info
      *
      * @param string $accountId
+     * @param ?string $accessToken
      *
      * @return array
      * @throws GuzzleException
      */
-    public function returnTokenInformation(string $accountId): array
+    public function returnTokenInformation(string $accountId, string $accessToken = null): array
     {
+        $params = empty($accessToken) ? [] : ['access_token' => $accessToken];
         return $this->options
             ->getSync()
             ->setPath($this->options->getClientId(), $accountId)
+            ->setFormParams($params)
             ->setHeaderParams($this->options->getAuthorizationHeader(false))
             ->post(API::LIST['tokenInfo']);
     }


### PR DESCRIPTION
I was encountering issues due to the `returnTokenInformation` method not using the correct method type and missing the required `access_token` parameter so this PR fixes both of those problems. Here is the updated official documentation: https://developer.nylas.com/docs/api/v2/#post-/a/-client_id-/accounts/-id-/token-info